### PR TITLE
Change `dial_to_handler` to `dial`

### DIFF
--- a/zkchat-example/src/main.rs
+++ b/zkchat-example/src/main.rs
@@ -214,7 +214,7 @@ fn main() {
                     let addr = AddrComponent::P2P(n.into_bytes()).into();
                     // TODO: this will always open a new substream instead of reusing existing ones
                     if let Err(err) =
-                        swarm_controller.dial_to_handler(addr, transport.clone().with_upgrade(floodsub_upgrade.clone()))
+                        swarm_controller.dial(addr, transport.clone().with_upgrade(floodsub_upgrade.clone()))
                     {
                         info!("Error while dialing {:?}", err);
                     }


### PR DESCRIPTION
Hey there,
  I didn't see your zksummit presentation but I stumbled across it. Thanks for making this, it's a useful resource.

I found the chat example would not compile with `dial_to_handler` and I can see you were using `dial` in a previous commit. I didn't test this in the browser (emscripten) however it worked on console.

Keen to hear your thoughts :smile: 